### PR TITLE
feat(get prs): filter out draft PRs by default

### DIFF
--- a/pkg/cmd/common_cmd_test.go
+++ b/pkg/cmd/common_cmd_test.go
@@ -36,6 +36,7 @@ func TestCommonCmd_Filter_AllData(t *testing.T) {
       "nodes": null
     },
     "createdAt": "0001-01-01T00:00:00Z",
+    "isDraft": false,
     "labels": {
       "nodes": null
     },
@@ -65,6 +66,7 @@ func TestCommonCmd_Filter_AllData(t *testing.T) {
       "nodes": null
     },
     "createdAt": "0001-01-01T00:00:00Z",
+    "isDraft": false,
     "labels": {
       "nodes": null
     },
@@ -94,6 +96,7 @@ func TestCommonCmd_Filter_AllData(t *testing.T) {
       "nodes": null
     },
     "createdAt": "0001-01-01T00:00:00Z",
+    "isDraft": false,
     "labels": {
       "nodes": null
     },
@@ -138,6 +141,7 @@ func TestCommonCmd_Filter_FilterOnAuthor(t *testing.T) {
       "nodes": null
     },
     "createdAt": "0001-01-01T00:00:00Z",
+    "isDraft": false,
     "labels": {
       "nodes": null
     },

--- a/pkg/cmd/getcmd/get_prs.go
+++ b/pkg/cmd/getcmd/get_prs.go
@@ -19,6 +19,7 @@ type GetPrsCmd struct {
 	cmd.CommonCmd
 	ShowBots   bool
 	ShowHidden bool
+	ShowDrafts bool
 	Review     bool
 	Quiet      bool
 	Me         bool
@@ -50,6 +51,10 @@ Get a list of PRs with a custom query:
 
   dx get prs --raw is:private
 
+Get a list of PRs including drafts:
+
+  dx get prs --show-drafts
+
 `,
 		Aliases: []string{"pr", "pulls", "pull-requests"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,6 +71,8 @@ Get a list of PRs with a custom query:
 		"Show bot account PRs (default: false)")
 	cmd.Flags().BoolVarP(&c.ShowHidden, "show-hidden", "", false,
 		"Show PRs that are filtered by hidden labels (default: false)")
+	cmd.Flags().BoolVarP(&c.ShowDrafts, "show-drafts", "", false,
+		"Show draft PRs (default: false)")
 	cmd.Flags().BoolVarP(&c.Review, "review", "", false,
 		"Show PRs that are ready for review")
 	cmd.Flags().BoolVarP(&c.Quiet, "quiet", "", false,
@@ -86,6 +93,7 @@ func (c *GetPrsCmd) Run() error {
 	d := domain.NewGetPrs()
 	d.ShowHidden = c.ShowHidden
 	d.ShowBots = c.ShowBots
+	d.ShowDrafts = c.ShowDrafts
 	d.Me = c.Me
 	d.Review = c.Review
 	d.Raw = c.Raw
@@ -163,7 +171,7 @@ func (c *GetPrsCmd) Run() error {
 		fmt.Printf("\nDisplaying %d PRs\n", len(d.PullRequests))
 	}
 
-	if (d.FilteredBotAccounts + d.FilteredLabels) > 0 {
+	if (d.FilteredBotAccounts + d.FilteredLabels + d.FilteredDrafts) > 0 {
 		var flags []string
 		if d.FilteredBotAccounts > 0 {
 			flags = append(flags, "--show-bots")
@@ -171,7 +179,10 @@ func (c *GetPrsCmd) Run() error {
 		if d.FilteredLabels > 0 {
 			flags = append(flags, "--show-hidden")
 		}
-		fmt.Printf("\nFiltered %d PRs, use %s to view them\n", (d.FilteredBotAccounts + d.FilteredLabels), strings.Join(flags, ", "))
+		if d.FilteredDrafts > 0 {
+			flags = append(flags, "--show-drafts")
+		}
+		fmt.Printf("\nFiltered %d PRs, use %s to view them\n", (d.FilteredBotAccounts + d.FilteredLabels + d.FilteredDrafts), strings.Join(flags, ", "))
 	}
 
 	return nil

--- a/pkg/domain/get_prs.go
+++ b/pkg/domain/get_prs.go
@@ -24,6 +24,7 @@ var (
         url
         createdAt
         closed
+        isDraft
         author {
           login
         }
@@ -80,12 +81,14 @@ type GetPrs struct {
 	cmd.CommonOptions
 	ShowBots            bool
 	ShowHidden          bool
+	ShowDrafts          bool
 	Me                  bool
 	Review              bool
 	Raw                 string
 	PullRequests        []pr.PullRequest
 	FilteredLabels      int
 	FilteredBotAccounts int
+	FilteredDrafts      int
 }
 
 // PrData.
@@ -132,6 +135,7 @@ func (g *GetPrs) Run() error {
 
 	filteredOnLabels := 0
 	filteredOnAccounts := 0
+	filteredOnDrafts := 0
 
 	for _, pullRequest := range pulls {
 		if pullRequest.Display() {
@@ -139,17 +143,20 @@ func (g *GetPrs) Run() error {
 				filteredOnLabels++
 			} else if g.filterOnAccounts(pullRequest, cfg.GetBotAccounts()) {
 				filteredOnAccounts++
+			} else if g.filterOnDrafts(pullRequest) {
+				filteredOnDrafts++
 			} else {
 				pullsToReturn = append(pullsToReturn, pullRequest)
 			}
 		}
 	}
 
-	log.Logger().Debugf("Filtered %d/%d PR(s)", filteredOnLabels, filteredOnAccounts)
+	log.Logger().Debugf("Filtered %d/%d/%d PR(s)", filteredOnLabels, filteredOnAccounts, filteredOnDrafts)
 
 	g.PullRequests = pullsToReturn
 	g.FilteredLabels = filteredOnLabels
 	g.FilteredBotAccounts = filteredOnAccounts
+	g.FilteredDrafts = filteredOnDrafts
 
 	return nil
 }
@@ -215,6 +222,13 @@ func (g *GetPrs) filterOnLabels(pr pr.PullRequest, hiddenLabels []string) bool {
 		if pr.HasLabel(label) {
 			return !g.ShowHidden
 		}
+	}
+	return false
+}
+
+func (g *GetPrs) filterOnDrafts(pr pr.PullRequest) bool {
+	if pr.IsDraft {
+		return !g.ShowDrafts
 	}
 	return false
 }

--- a/pkg/domain/get_prs_test.go
+++ b/pkg/domain/get_prs_test.go
@@ -163,6 +163,77 @@ func TestGetPrs_Run_ShowBots(t *testing.T) {
 	assert.Equal(t, 6, len(d.PullRequests))
 }
 
+func TestGetPrs_Run_ShowDrafts(t *testing.T) {
+	d := NewGetPrs()
+	d.ShowDrafts = true
+
+	var authConfig auth.Config = &auth.FakeConfig{
+		Hosts: map[string]*auth.HostConfig{
+			"github.com": {User: "user", Token: "token"},
+		},
+	}
+
+	http := &api.FakeHTTP{}
+	client := api.NewClient(authConfig, api.ReplaceTripper(http))
+	d.SetGithubClient(client)
+
+	dxConfig := configfakes.FakeConfig{}
+	dxConfig.GetMaxAgeOfPRsReturns(-1)
+	dxConfig.GetBotAccountsReturns([]string{"dependabot-preview"})
+	dxConfig.GetHiddenLabelsReturns([]string{"do-not-merge/hold"})
+	dxConfig.GetConfiguredServersReturns([]string{"github.com"})
+	dxConfig.GetReposToQueryReturns([]string{"github/repo1", "github/repo2"})
+
+	d.SetDxConfig(&dxConfig)
+
+	http.StubResponse(200, bytes.NewBufferString(fmt.Sprint(userResponse)))
+	http.StubResponse(200, bytes.NewBufferString(expectedResponse("github.com")))
+
+	err := d.Run()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(http.Requests))
+
+	// with --show-drafts the draft PR (#789) is included
+	assert.Equal(t, 6, len(d.PullRequests))
+	assert.Equal(t, 0, d.FilteredDrafts)
+}
+
+func TestGetPrs_Run_FilterDrafts(t *testing.T) {
+	d := NewGetPrs()
+
+	var authConfig auth.Config = &auth.FakeConfig{
+		Hosts: map[string]*auth.HostConfig{
+			"github.com": {User: "user", Token: "token"},
+		},
+	}
+
+	http := &api.FakeHTTP{}
+	client := api.NewClient(authConfig, api.ReplaceTripper(http))
+	d.SetGithubClient(client)
+
+	dxConfig := configfakes.FakeConfig{}
+	dxConfig.GetMaxAgeOfPRsReturns(-1)
+	dxConfig.GetBotAccountsReturns([]string{"dependabot-preview"})
+	dxConfig.GetHiddenLabelsReturns([]string{"do-not-merge/hold"})
+	dxConfig.GetConfiguredServersReturns([]string{"github.com"})
+	dxConfig.GetReposToQueryReturns([]string{"github/repo1", "github/repo2"})
+
+	d.SetDxConfig(&dxConfig)
+
+	http.StubResponse(200, bytes.NewBufferString(fmt.Sprint(userResponse)))
+	http.StubResponse(200, bytes.NewBufferString(expectedResponse("github.com")))
+
+	err := d.Run()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(http.Requests))
+
+	// by default the draft PR (#789) is filtered out
+	assert.Equal(t, 5, len(d.PullRequests))
+	assert.Equal(t, 1, d.FilteredDrafts)
+}
+
 func expectedResponse(host string) string {
 	variables := make(map[string]string)
 	variables["Host"] = host
@@ -177,7 +248,8 @@ func expectedResponse(host string) string {
 			{"number":792,"title":"chore: test to 0.0.923","url":"https://{{.Host}}/test_repo_two/pull/792","createdAt":"2020-05-15T10:07:30Z","closed":false,"author":{"login":"-bot"},"repository":{"nameWithOwner":"my_owner"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
 			{"number":44,"title":"chore: prompt for version if not supplied","url":"https://{{.Host}}/plumming/dx/pull/44","createdAt":"2020-05-15T08:07:26Z","closed":false,"author":{"login":"me"},"repository":{"nameWithOwner":"plumming/dx"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XL"},{"name":"do-not-merge/hold"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"","description":"Not mergeable. Needs approved label.","context":"Merge Status"},{"state":"SUCCESS","targetUrl":"https://dashboard/PR-44/4","description":"Pipeline successful","context":"pr-build"}]}}}]}},
      		{"number":791,"title":"chore: my-service to 0.0.717","url":"https://{{.Host}}/test_repo_two/pull/791","createdAt":"2020-05-14T23:12:56Z","closed":false,"author":{"login":"bot"},"repository":{"nameWithOwner":"my_owner"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
-			{"number":790,"title":"chore: test to 0.0.922","url":"https://{{.Host}}/test_repo_two/pull/790","createdAt":"2020-05-14T22:53:14Z","closed":false,"author":{"login":"bot"},"repository":{"nameWithOwner":"testOwners"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}}
+			{"number":790,"title":"chore: test to 0.0.922","url":"https://{{.Host}}/test_repo_two/pull/790","createdAt":"2020-05-14T22:53:14Z","closed":false,"author":{"login":"bot"},"repository":{"nameWithOwner":"testOwners"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
+			{"number":789,"title":"chore: draft pr","url":"https://{{.Host}}/test_repo_two/pull/789","createdAt":"2020-05-14T22:00:14Z","closed":false,"isDraft":true,"author":{"login":"me"},"repository":{"nameWithOwner":"testOwners"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}}
 		]}
 	}
 }`)

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -19,6 +19,7 @@ type PullRequest struct {
 	Labels         Labels     `json:"labels"`
 	Commits        Commits    `json:"commits"`
 	Closed         bool       `json:"closed"`
+	IsDraft        bool       `json:"isDraft"`
 	Repository     Repository `json:"repository"`
 	Comments       Comments   `json:"comments"`
 	ReviewDecision string     `json:"reviewDecision"`


### PR DESCRIPTION
## Summary

`dx get prs` now hides **draft PRs by default**. A new `--show-drafts` flag includes them, following the same convention as the existing `--show-bots` and `--show-hidden` flags.

## Changes

- **GraphQL**: fetch `isDraft` for each PR
- **`PullRequest`**: new `IsDraft` field
- **`GetPrs`**: new `ShowDrafts` option, `FilteredDrafts` counter, and a `filterOnDrafts` step in the filter loop (mirrors `filterOnLabels`/`filterOnAccounts`)
- **CLI**: new `--show-drafts` flag; when drafts are hidden, the "Filtered N PRs, use ... to view them" hint now includes `--show-drafts`
- **Help**: added a usage example

## Tests

- Added a draft PR to the stub response plus `TestGetPrs_Run_FilterDrafts` (default hides it) and `TestGetPrs_Run_ShowDrafts` (`--show-drafts` includes it)
- Updated the JMESPath golden-output tests for the new `isDraft` field

Full test suite and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)