### PR TITLE
fix(lint): resolve gosec taint findings and pin golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,5 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v2.11
           args: --timeout=300s

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -266,6 +266,7 @@ func (c *Client) Download(url string) (*http.Response, error) {
 }
 
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	// #nosec G704 -- the request targets the user's own configured GitHub (Enterprise) host; the CLI acts on their behalf.
 	return c.http.Do(req)
 }
 

--- a/pkg/cmd/editcmd/edit_config.go
+++ b/pkg/cmd/editcmd/edit_config.go
@@ -63,6 +63,7 @@ func (c *EditConfigCmd) Run() error {
 		log.Logger().Fatal(err)
 	}
 
+	// #nosec G702 -- editor is the user's own $EDITOR (default vi), launched locally on a process-created temp file.
 	cmd := exec.Command(editor, f.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/cmd/shellcmd/shell.go
+++ b/pkg/cmd/shellcmd/shell.go
@@ -110,6 +110,7 @@ func (c *ShellCmd) Run() error {
 		rcFile = zshRcFile + "\nexport PS1=" + prompt + "\nexport KUBECONFIG=\"" + tmpConfigFileName + "\"\n"
 		tmpRCFileName = tmpDirName + "/.zshrc"
 	}
+	// #nosec G703 -- tmpRCFileName lives inside a process-created MkdirTemp directory, not user-supplied input.
 	err = os.WriteFile(tmpRCFileName, []byte(rcFile), 0600)
 	if err != nil {
 		return err
@@ -121,10 +122,12 @@ func (c *ShellCmd) Run() error {
 	fmt.Printf("All changes to the Kubernetes context like changing environment, namespace or context will be local to this shell\n")
 	fmt.Printf("To return to the global context use the command: exit\n\n")
 
+	// #nosec G702 -- shell is the basename of the user's own $SHELL, launched interactively on their behalf.
 	e := exec.Command(shell, "-rcfile", tmpRCFileName, "-i")
 	if shell == "zsh" {
 		env := os.Environ()
 		env = append(env, fmt.Sprintf("ZDOTDIR=%s", tmpDirName))
+		// #nosec G702 -- shell is the basename of the user's own $SHELL, launched interactively on their behalf.
 		e = exec.Command(shell, "-i")
 		e.Env = env
 	}


### PR DESCRIPTION
## Problem

Every open PR is failing the `lint` (golangci-lint) check — including the Dependabot dependency bumps (#390–#396) that don't touch any of the flagged code. The Build check passes on all of them; only lint is red.

The workflow runs `golangci/golangci-lint-action@v9` with **no `version:` set**, so it tracks `latest`. A recent golangci-lint release bundled new gosec **taint-analysis** rules (G702/G703/G704) that flag pre-existing, intentional CLI behaviour:

```
pkg/api/client.go:269:18: G704: SSRF via taint analysis (gosec)
pkg/cmd/editcmd/edit_config.go:66:21: G702: Command injection via taint analysis (gosec)
pkg/cmd/shellcmd/shell.go:113:20: G703: Path traversal via taint analysis (gosec)
pkg/cmd/shellcmd/shell.go:124:19: G702: Command injection via taint analysis (gosec)
pkg/cmd/shellcmd/shell.go:128:19: G702: Command injection via taint analysis (gosec)
```

## Fix

Each finding is the user acting on their own behalf — their `$EDITOR`, their `$SHELL`, their configured GitHub (Enterprise) host — on process-created temp paths (`os.MkdirTemp`/`os.CreateTemp`). They're annotated with rule-specific `#nosec` directives plus a justification, matching the existing convention in `pkg/util/command.go`.

I also **pinned the linter to `v2.11`** (latest patch) in the workflow, as the existing comment in that file already instructs ("the version of golangci-lint ... must be specified"). Without a pin, future linter releases can silently re-break CI on every open PR.

## Result

`golangci-lint run` is clean for the gosec rules. Once this merges, the Dependabot PRs (#390–#396) just need a rebase / re-run to go green.

## Heads-up (follow-up, not in this PR)

golangci-lint **v2.12** changes `goconst` behaviour and surfaces ~40 new findings (mostly repeated string literals in `_test.go`). Pinning to v2.11 avoids that for now; bumping the pin to v2.12 later should be a deliberate, separate change that also addresses those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)