### PR TITLE
feat(get prs): add --hide-approved to filter out approved PRs

### DIFF
--- a/pkg/cmd/getcmd/get_prs.go
+++ b/pkg/cmd/getcmd/get_prs.go
@@ -17,16 +17,17 @@ import (
 
 type GetPrsCmd struct {
 	cmd.CommonCmd
-	ShowBots   bool
-	ShowHidden bool
-	ShowDrafts bool
-	Review     bool
-	Quiet      bool
-	Me         bool
-	Copy       bool
-	Raw        string
-	Cmd        *cobra.Command
-	Args       []string
+	ShowBots     bool
+	ShowHidden   bool
+	ShowDrafts   bool
+	HideApproved bool
+	Review       bool
+	Quiet        bool
+	Me           bool
+	Copy         bool
+	Raw          string
+	Cmd          *cobra.Command
+	Args         []string
 }
 
 func NewGetPrsCmd() *cobra.Command {
@@ -55,6 +56,10 @@ Get a list of PRs including drafts:
 
   dx get prs --show-drafts
 
+Get a list of PRs excluding approved ones:
+
+  dx get prs --hide-approved
+
 `,
 		Aliases: []string{"pr", "pulls", "pull-requests"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -73,6 +78,8 @@ Get a list of PRs including drafts:
 		"Show PRs that are filtered by hidden labels (default: false)")
 	cmd.Flags().BoolVarP(&c.ShowDrafts, "show-drafts", "", false,
 		"Show draft PRs (default: false)")
+	cmd.Flags().BoolVarP(&c.HideApproved, "hide-approved", "", false,
+		"Hide approved PRs (default: false)")
 	cmd.Flags().BoolVarP(&c.Review, "review", "", false,
 		"Show PRs that are ready for review")
 	cmd.Flags().BoolVarP(&c.Quiet, "quiet", "", false,
@@ -94,6 +101,7 @@ func (c *GetPrsCmd) Run() error {
 	d.ShowHidden = c.ShowHidden
 	d.ShowBots = c.ShowBots
 	d.ShowDrafts = c.ShowDrafts
+	d.HideApproved = c.HideApproved
 	d.Me = c.Me
 	d.Review = c.Review
 	d.Raw = c.Raw
@@ -183,6 +191,10 @@ func (c *GetPrsCmd) Run() error {
 			flags = append(flags, "--show-drafts")
 		}
 		fmt.Printf("\nFiltered %d PRs, use %s to view them\n", (d.FilteredBotAccounts + d.FilteredLabels + d.FilteredDrafts), strings.Join(flags, ", "))
+	}
+
+	if d.FilteredApproved > 0 {
+		fmt.Printf("\nFiltered %d approved PRs, remove --hide-approved to view them\n", d.FilteredApproved)
 	}
 
 	return nil

--- a/pkg/domain/get_prs.go
+++ b/pkg/domain/get_prs.go
@@ -82,6 +82,7 @@ type GetPrs struct {
 	ShowBots            bool
 	ShowHidden          bool
 	ShowDrafts          bool
+	HideApproved        bool
 	Me                  bool
 	Review              bool
 	Raw                 string
@@ -89,6 +90,7 @@ type GetPrs struct {
 	FilteredLabels      int
 	FilteredBotAccounts int
 	FilteredDrafts      int
+	FilteredApproved    int
 }
 
 // PrData.
@@ -136,6 +138,7 @@ func (g *GetPrs) Run() error {
 	filteredOnLabels := 0
 	filteredOnAccounts := 0
 	filteredOnDrafts := 0
+	filteredOnApproved := 0
 
 	for _, pullRequest := range pulls {
 		if pullRequest.Display() {
@@ -145,18 +148,21 @@ func (g *GetPrs) Run() error {
 				filteredOnAccounts++
 			} else if g.filterOnDrafts(pullRequest) {
 				filteredOnDrafts++
+			} else if g.filterOnApproved(pullRequest) {
+				filteredOnApproved++
 			} else {
 				pullsToReturn = append(pullsToReturn, pullRequest)
 			}
 		}
 	}
 
-	log.Logger().Debugf("Filtered %d/%d/%d PR(s)", filteredOnLabels, filteredOnAccounts, filteredOnDrafts)
+	log.Logger().Debugf("Filtered %d/%d/%d/%d PR(s)", filteredOnLabels, filteredOnAccounts, filteredOnDrafts, filteredOnApproved)
 
 	g.PullRequests = pullsToReturn
 	g.FilteredLabels = filteredOnLabels
 	g.FilteredBotAccounts = filteredOnAccounts
 	g.FilteredDrafts = filteredOnDrafts
+	g.FilteredApproved = filteredOnApproved
 
 	return nil
 }
@@ -229,6 +235,13 @@ func (g *GetPrs) filterOnLabels(pr pr.PullRequest, hiddenLabels []string) bool {
 func (g *GetPrs) filterOnDrafts(pr pr.PullRequest) bool {
 	if pr.IsDraft {
 		return !g.ShowDrafts
+	}
+	return false
+}
+
+func (g *GetPrs) filterOnApproved(pr pr.PullRequest) bool {
+	if pr.IsApproved() {
+		return g.HideApproved
 	}
 	return false
 }

--- a/pkg/domain/get_prs_test.go
+++ b/pkg/domain/get_prs_test.go
@@ -234,6 +234,77 @@ func TestGetPrs_Run_FilterDrafts(t *testing.T) {
 	assert.Equal(t, 1, d.FilteredDrafts)
 }
 
+func TestGetPrs_Run_ShowApprovedByDefault(t *testing.T) {
+	d := NewGetPrs()
+
+	var authConfig auth.Config = &auth.FakeConfig{
+		Hosts: map[string]*auth.HostConfig{
+			"github.com": {User: "user", Token: "token"},
+		},
+	}
+
+	http := &api.FakeHTTP{}
+	client := api.NewClient(authConfig, api.ReplaceTripper(http))
+	d.SetGithubClient(client)
+
+	dxConfig := configfakes.FakeConfig{}
+	dxConfig.GetMaxAgeOfPRsReturns(-1)
+	dxConfig.GetBotAccountsReturns([]string{"dependabot-preview"})
+	dxConfig.GetHiddenLabelsReturns([]string{"do-not-merge/hold"})
+	dxConfig.GetConfiguredServersReturns([]string{"github.com"})
+	dxConfig.GetReposToQueryReturns([]string{"github/repo1", "github/repo2"})
+
+	d.SetDxConfig(&dxConfig)
+
+	http.StubResponse(200, bytes.NewBufferString(fmt.Sprint(userResponse)))
+	http.StubResponse(200, bytes.NewBufferString(expectedResponse("github.com")))
+
+	err := d.Run()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(http.Requests))
+
+	// by default the approved PR (#790) is included
+	assert.Equal(t, 5, len(d.PullRequests))
+	assert.Equal(t, 0, d.FilteredApproved)
+}
+
+func TestGetPrs_Run_HideApproved(t *testing.T) {
+	d := NewGetPrs()
+	d.HideApproved = true
+
+	var authConfig auth.Config = &auth.FakeConfig{
+		Hosts: map[string]*auth.HostConfig{
+			"github.com": {User: "user", Token: "token"},
+		},
+	}
+
+	http := &api.FakeHTTP{}
+	client := api.NewClient(authConfig, api.ReplaceTripper(http))
+	d.SetGithubClient(client)
+
+	dxConfig := configfakes.FakeConfig{}
+	dxConfig.GetMaxAgeOfPRsReturns(-1)
+	dxConfig.GetBotAccountsReturns([]string{"dependabot-preview"})
+	dxConfig.GetHiddenLabelsReturns([]string{"do-not-merge/hold"})
+	dxConfig.GetConfiguredServersReturns([]string{"github.com"})
+	dxConfig.GetReposToQueryReturns([]string{"github/repo1", "github/repo2"})
+
+	d.SetDxConfig(&dxConfig)
+
+	http.StubResponse(200, bytes.NewBufferString(fmt.Sprint(userResponse)))
+	http.StubResponse(200, bytes.NewBufferString(expectedResponse("github.com")))
+
+	err := d.Run()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(http.Requests))
+
+	// with --hide-approved the approved PR (#790) is filtered out
+	assert.Equal(t, 4, len(d.PullRequests))
+	assert.Equal(t, 1, d.FilteredApproved)
+}
+
 func expectedResponse(host string) string {
 	variables := make(map[string]string)
 	variables["Host"] = host
@@ -248,7 +319,7 @@ func expectedResponse(host string) string {
 			{"number":792,"title":"chore: test to 0.0.923","url":"https://{{.Host}}/test_repo_two/pull/792","createdAt":"2020-05-15T10:07:30Z","closed":false,"author":{"login":"-bot"},"repository":{"nameWithOwner":"my_owner"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
 			{"number":44,"title":"chore: prompt for version if not supplied","url":"https://{{.Host}}/plumming/dx/pull/44","createdAt":"2020-05-15T08:07:26Z","closed":false,"author":{"login":"me"},"repository":{"nameWithOwner":"plumming/dx"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XL"},{"name":"do-not-merge/hold"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"","description":"Not mergeable. Needs approved label.","context":"Merge Status"},{"state":"SUCCESS","targetUrl":"https://dashboard/PR-44/4","description":"Pipeline successful","context":"pr-build"}]}}}]}},
      		{"number":791,"title":"chore: my-service to 0.0.717","url":"https://{{.Host}}/test_repo_two/pull/791","createdAt":"2020-05-14T23:12:56Z","closed":false,"author":{"login":"bot"},"repository":{"nameWithOwner":"my_owner"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
-			{"number":790,"title":"chore: test to 0.0.922","url":"https://{{.Host}}/test_repo_two/pull/790","createdAt":"2020-05-14T22:53:14Z","closed":false,"author":{"login":"bot"},"repository":{"nameWithOwner":"testOwners"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
+			{"number":790,"title":"chore: test to 0.0.922","url":"https://{{.Host}}/test_repo_two/pull/790","createdAt":"2020-05-14T22:53:14Z","closed":false,"reviewDecision":"APPROVED","author":{"login":"bot"},"repository":{"nameWithOwner":"testOwners"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"},{"name":"updatebot"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"PENDING","targetUrl":"http://dec","description":"Not mergeable. Needs approved label.","context":"tide"},{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}},
 			{"number":789,"title":"chore: draft pr","url":"https://{{.Host}}/test_repo_two/pull/789","createdAt":"2020-05-14T22:00:14Z","closed":false,"isDraft":true,"author":{"login":"me"},"repository":{"nameWithOwner":"testOwners"},"mergeable":"MERGEABLE","labels":{"nodes":[{"name":"size/XS"}]},"commits":{"nodes":[{"commit":{"status":{"contexts":[{"state":"SUCCESS","targetUrl":null,"description":"All Tasks have completed executing","context":"promotion-build"}]}}}]}}
 		]}
 	}

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -41,6 +41,7 @@ const (
 	error       = "ERROR"
 	conflicting = "CONFLICTING"
 	unknown     = "UNKNOWN"
+	approved    = "APPROVED"
 )
 
 func (p *PullRequest) Display() bool {
@@ -122,7 +123,7 @@ func (p *PullRequest) ColoredTitle() string {
 
 func (p *PullRequest) ColoredReviewDecision() string {
 	switch p.ReviewDecision {
-	case "APPROVED":
+	case approved:
 		return util.ColorInfo("Approved")
 	case "REVIEW_REQUIRED":
 		return util.ColorWarning("Required")
@@ -131,6 +132,10 @@ func (p *PullRequest) ColoredReviewDecision() string {
 	default:
 		return p.ReviewDecision
 	}
+}
+
+func (p *PullRequest) IsApproved() bool {
+	return p.ReviewDecision == approved
 }
 
 func (p *PullRequest) TrimmedTitle() string {


### PR DESCRIPTION
## Summary

Adds a `--hide-approved` flag to `dx get prs` that filters out PRs whose review decision is `APPROVED`. The flag is **disabled by default** — approved PRs are shown unless you opt in.

This mirrors the existing filter pipeline (hidden labels → bot accounts → drafts) by adding a `filterOnApproved` step and a `FilteredApproved` counter. A new `PullRequest.IsApproved()` helper encapsulates the review-decision check (and the `"APPROVED"` literal is now a shared `approved` constant).

Because this flag is **opt-in** (the other filters hide by default and are revealed with `--show-*`), the summary prints a dedicated hint — "remove `--hide-approved` to view them" — instead of folding it into the `--show-*` hint.

## Example

```
dx get prs --hide-approved
```

## Tests

- `TestGetPrs_Run_ShowApprovedByDefault` — approved PR included by default (`FilteredApproved == 0`)
- `TestGetPrs_Run_HideApproved` — `--hide-approved` filters it out (`FilteredApproved == 1`)
- Marked an existing fixture PR (#790) as `APPROVED`; all other test counts are unchanged since the flag defaults off.

Build, full test suite, and `golangci-lint` all pass locally.

## ⚠️ Stacked on #397

This branch is built on top of #397 (`--show-drafts`). Until #397 merges, this PR's diff will also show the draft-PR commit; once #397 lands, the diff collapses to just the `--hide-approved` change. Please review/merge #397 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)