### PR TITLE
fix(prs): dedupe stale check runs when colouring PRs

### DIFF
--- a/pkg/domain/get_prs.go
+++ b/pkg/domain/get_prs.go
@@ -53,11 +53,13 @@ var (
                       state
                       context
                       description
+                      createdAt
                     }
                     ...on CheckRun {
                       conclusion
                       name
                       title
+                      startedAt
                     }
                   }
                 }

--- a/pkg/pr/common.go
+++ b/pkg/pr/common.go
@@ -1,5 +1,7 @@
 package pr
 
+import "time"
+
 type Comments struct {
 	TotalCount int `json:"totalCount"`
 }
@@ -42,10 +44,21 @@ type StatusContext struct {
 }
 
 type Context struct {
-	State       string `json:"state"`
-	Description string `json:"description"`
-	Context     string `json:"context"`
-	Conclusion  string `json:"conclusion"`
-	Name        string `json:"name"`
-	Title       string `json:"title"`
+	State       string    `json:"state"`
+	Description string    `json:"description"`
+	Context     string    `json:"context"`
+	Conclusion  string    `json:"conclusion"`
+	Name        string    `json:"name"`
+	Title       string    `json:"title"`
+	StartedAt   time.Time `json:"startedAt"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+// timestamp returns the time the context was last run, preferring a CheckRun's
+// startedAt and falling back to a StatusContext's createdAt.
+func (c Context) timestamp() time.Time {
+	if !c.StartedAt.IsZero() {
+		return c.StartedAt
+	}
+	return c.CreatedAt
 }

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -62,9 +62,44 @@ func (p *PullRequest) LabelsString() string {
 	return strings.Join(labels, ", ")
 }
 
+// latestContexts deduplicates the status checks on the latest commit, keeping
+// only the most recent run of each. GitHub's statusCheckRollup can contain
+// multiple runs of the same check (for example a failed run followed by a
+// successful re-run); only the latest run reflects the current state, so the
+// stale entries must be discarded to avoid reporting a check as failed when it
+// has since passed.
+func (p *PullRequest) latestContexts() []Context {
+	var keys []string
+	latest := map[string]Context{}
+	var result []Context
+	for _, c := range p.Commits.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes {
+		key := c.Name
+		if key == "" {
+			key = c.Context
+		}
+		if key == "" {
+			// Nothing to deduplicate on, keep the context as-is.
+			result = append(result, c)
+			continue
+		}
+		if existing, ok := latest[key]; ok {
+			if c.timestamp().Before(existing.timestamp()) {
+				continue
+			}
+		} else {
+			keys = append(keys, key)
+		}
+		latest[key] = c
+	}
+	for _, key := range keys {
+		result = append(result, latest[key])
+	}
+	return result
+}
+
 func (p *PullRequest) contexts() []string {
 	var contexts []string
-	for _, c := range p.Commits.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes {
+	for _, c := range p.latestContexts() {
 		if c.Context != "" && c.Context != "tide" && c.Context != "keeper" && c.Context != "Merge Status" {
 			contexts = append(contexts, c.State)
 		}
@@ -100,7 +135,7 @@ func (p *PullRequest) ContextsString() string {
 
 func (p *PullRequest) FailedContexts() []Context {
 	var failedContexts []Context
-	for _, c := range p.Commits.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes {
+	for _, c := range p.latestContexts() {
 		if c.Context != "" && c.Context != "tide" && c.Context != "keeper" && c.Context != "Merge Status" && c.State == failure {
 			failedContexts = append(failedContexts, c)
 		}

--- a/pkg/pr/pr_test.go
+++ b/pkg/pr/pr_test.go
@@ -2,6 +2,7 @@ package pr
 
 import (
 	"testing"
+	"time"
 
 	"github.com/plumming/dx/pkg/util"
 
@@ -124,6 +125,64 @@ func TestPullRequest_ContextsString(t *testing.T) {
 				},
 			}
 			assert.Equal(t, pr.ContextsString(), test.exp)
+		})
+	}
+}
+
+func TestPullRequest_ContextsString_DeduplicatesStaleRuns(t *testing.T) {
+	older := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+
+	var tests = []struct {
+		name     string
+		contexts []Context
+		exp      string
+	}{
+		{
+			name: "stale_failure_superseded_by_successful_rerun",
+			contexts: []Context{
+				{Conclusion: "FAILURE", Name: "commit-policy", StartedAt: older},
+				{Conclusion: "SUCCESS", Name: "commit-policy", StartedAt: newer},
+				{Conclusion: "SUCCESS", Name: "Run tests", StartedAt: newer},
+			},
+			exp: "SUCCESS",
+		},
+		{
+			name: "successful_run_superseded_by_failing_rerun",
+			contexts: []Context{
+				{Conclusion: "SUCCESS", Name: "commit-policy", StartedAt: older},
+				{Conclusion: "FAILURE", Name: "commit-policy", StartedAt: newer},
+			},
+			exp: "FAILURE",
+		},
+		{
+			name: "stale_failure_regardless_of_node_order",
+			contexts: []Context{
+				{Conclusion: "SUCCESS", Name: "commit-policy", StartedAt: newer},
+				{Conclusion: "FAILURE", Name: "commit-policy", StartedAt: older},
+			},
+			exp: "SUCCESS",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pr := PullRequest{
+				Commits: Commits{
+					Nodes: []CommitEntry{
+						{
+							Commit: Commit{
+								StatusCheckRollup: StatusCheckRollup{
+									Contexts: StatusContext{
+										Nodes: test.contexts,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			assert.Equal(t, test.exp, pr.ContextsString())
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`dx get prs` colours a PR title red whenever any status check reports `FAILURE`/`ERROR`. GitHub's `statusCheckRollup` can contain **multiple runs of the same check** — for example a failed run followed by a successful re-run. dx collected *every* run, so a single stale `FAILURE` made the title render red even though the check had since passed and the PR was approved & mergeable.

Concrete example: PR 220 on `mcp-gateway` had two `commit-policy / commit-policy` entries — an older `FAILURE` and a newer `SUCCESS`. GitHub's UI dedupes by check name and shows it green, but dx flagged the stale failed run and coloured the title red.

## Fix

Deduplicate contexts by name (CheckRun) / context (StatusContext), keeping only the **most recently started run** of each. `ContextsString` and `FailedContexts` now reflect the current state of each check.

- Added `startedAt` (CheckRun) and `createdAt` (StatusContext) to the GraphQL query and `Context` struct to determine which run is latest.
- New `latestContexts()` helper performs the dedup; both `contexts()` and `FailedContexts()` route through it.
- Added tests covering stale-failure-superseded-by-success, success-superseded-by-failure, and node-order independence.

## Testing

`go test ./pkg/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)